### PR TITLE
Add deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+
+RUN mkdir /app
+ADD . /app
+
+WORKDIR /app
+RUN npm install
+
+EXPOSE 8080
+CMD npm run dev

--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -22,6 +22,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
 
   // these devServer options should be customized in /config/index.js
   devServer: {
+    disableHostCheck: true,
     clientLogLevel: 'warning',
     historyApiFallback: {
       rewrites: [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Gemma Dominey",
   "private": true,
   "scripts": {
-    "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
+    "dev": "webpack-dev-server --host 0.0.0.0 --inline --progress --config build/webpack.dev.conf.js",
     "start": "npm run dev",
     "build": "node build/build.js"
   },


### PR DESCRIPTION
Temporary for dev, exposes on 0.0.0.0:80 with no auth. Needs a proxy with HTTP basic auth and an actual web server, not the webpack dev server.

Also should refine `Dockerfile` to cache `npm install` for faster container builds.